### PR TITLE
Removed hwmonitor check for Lion

### DIFF
--- a/hwmonitor.rb
+++ b/hwmonitor.rb
@@ -6,7 +6,6 @@ class Hwmonitor < Formula
 
   head "https://github.com/kozlek/HWSensors"
 
-  depends_on :macos => :lion
   depends_on :xcode => :build
 
   def install


### PR DESCRIPTION
The reason for that is the deprecation of all macOS versions below Mavericks as stated in [this merge request](https://github.com/Homebrew/brew/pull/5599)